### PR TITLE
wrap password in quotes

### DIFF
--- a/main.py
+++ b/main.py
@@ -590,7 +590,7 @@ class Login(Gtk.Window):#
             #f.close()
             if os.path.isdir(f'{ os.environ["HOME"] }/.adi'):
                 rmtree(f'{ os.environ["HOME"] }/.adi')
-            InsAltStoreCMD = f"""{export_anisette} ; {(AltServer)} -u {UDID} -a {apple_id} -p {password} {PATH} > {("$HOME/.local/share/althea/log.txt")}"""
+            InsAltStoreCMD = f"""{export_anisette} ; {(AltServer)} -u {UDID} -a {apple_id} -p \"{password}\" {PATH} > {("$HOME/.local/share/althea/log.txt")}"""
             InsAltStore = subprocess.Popen(
                 InsAltStoreCMD,
                 stdin=subprocess.PIPE,


### PR DESCRIPTION
a password containing certain characters causes sh to throw an error. this includes quotes themselves and thus further sanitization should be done