### PR TITLE
Change pairing check command to validate

### DIFF
--- a/main.py
+++ b/main.py
@@ -161,7 +161,7 @@ def on_abtdlg(self):
     about.destroy()
 
 def paircheck():  # Check if the device is paired already
-    pairchecking = subprocess.run('idevicepair pair | grep -q "SUCCESS"', shell=True)
+    pairchecking = subprocess.run('idevicepair validate | grep -q "SUCCESS"', shell=True) # use validate instaed of pair, pair causes error -5 if already paired
     if pairchecking.returncode == 0:
         return False
     else:


### PR DESCRIPTION
Updated the pairing check command to use 'idevicepair validate' instead of 'idevicepair pair' to avoid error -5.

On Fedora 43, the OS itself automatically handles pairing with iPhone in order to provide access to features like USB Tethering and viewing iPhone documents. The `paircheck`  method would call `idevicepair pair` but would always fail since it was checking for success but the command would return `ERROR: Device 00000000-0000000000000000 returned unhandled error code -5`. Using `idevicepair validate` will always return successful if the device has already been paired.

Before:
```
Detected device:iphone
Starting notification connection to device: iphone
Failed to start notification connection. There was an error connecting to the device.
ERROR: Device 00008150-000A61A40CC0401C returned unhandled error code -5
None
```

After:
`Notify: Installation Succeeded`