### PR TITLE
Stability fixes for the install/pairing flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ log.txt
 old
 traybackup.py
 .directory
+CLAUDE.md
+__pycache__/

--- a/main.py
+++ b/main.py
@@ -341,34 +341,45 @@ def read_install_log(log_path):
         return handle.read()
 
 
+# The AltStore feed lists two apps both named "AltStore" (the stable app and
+# a separate beta published under com.rileytestut.AltStore.Beta), so match on
+# bundleIdentifier rather than name to avoid depending on feed ordering.
+ALTSTORE_BUNDLE_ID = "com.rileytestut.AltStore"
+
+
 def altstore_download(value):
-    # setting the base URL value
     baseUrl = "https://cdn.altstore.io/file/altstore/apps.json"
 
-    # retrieving data from JSON Data
-    json_data = requests.get(baseUrl)
-    if json_data.status_code == 200:
-        data = json_data.json()
-        for app in data['apps']:
-            if app['name'] == "AltStore":
+    try:
+        json_data = requests.get(baseUrl, timeout=30)
+    except requests.RequestException:
+        return False
+    if json_data.status_code != 200:
+        return False
+    data = json_data.json()
+    for app in data['apps']:
+        if app.get('bundleIdentifier') == ALTSTORE_BUNDLE_ID:
+            for ver_entry in app['versions']:
+                latest = ver_entry.get('downloadURL', '')
+                if not latest.endswith('.ipa'):
+                    continue  # skip Patreon-gated entries (no direct .ipa)
+                ipa_path = f'{(altheapath)}/AltStore.ipa'
                 if value == "Check":
-                    size = app['versions'][0]['size']
-                    return size == os.path.getsize(f'{(altheapath)}/AltStore.ipa')
-                    break
+                    if not os.path.isfile(ipa_path):
+                        return False
+                    return ver_entry['size'] == os.path.getsize(ipa_path)
                 if value == "Download":
-                    latest = app['versions'][0]['downloadURL']
-                    r = requests.get(
-                        latest,
-                        allow_redirects=True,
-                    )
+                    try:
+                        r = requests.get(latest, allow_redirects=True, timeout=600)
+                        r.raise_for_status()
+                    except requests.RequestException:
+                        return False
                     latest_filename = latest.split('/')[-1]
                     open(f"{(altheapath)}/{(latest_filename)}", "wb").write(r.content)
-                    os.rename(f"{(altheapath)}/{(latest_filename)}", f"{(altheapath)}/AltStore.ipa")
-                    subprocess.run(f"chmod 755 {(altheapath)}/AltStore.ipa", shell=True)
-                    break
-        return True
-    else:
-        return False
+                    os.replace(f"{(altheapath)}/{(latest_filename)}", ipa_path)
+                    return True
+            return False
+    return False
 
 def ios_version():
     silent_remove(f"{(altheapath)}/ideviceinfo.txt")

--- a/main.py
+++ b/main.py
@@ -333,6 +333,14 @@ def silent_remove(filename):
         if e.errno != errno.ENOENT:  # errno.ENOENT = no such file or directory
             raise  # re-raise exception if a different error occurred
 
+
+def read_install_log(log_path):
+    if not os.path.exists(log_path):
+        return ""
+    with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
+        return handle.read()
+
+
 def altstore_download(value):
     # setting the base URL value
     baseUrl = "https://cdn.altstore.io/file/altstore/apps.json"
@@ -561,7 +569,13 @@ class Login(Gtk.Window):
     def on_click_me_clicked1(self):
         self.realthread1 = threading.Thread(target=self.onclickmethread)
         self.realthread1.start()
-        GLib.idle_add(self.install_process)
+        self.start_install_monitor()
+
+    def start_install_monitor(self):
+        self.WarnTime = 0
+        self.TwoFactorTime = 0
+        self.monitor_stopped = False
+        GLib.timeout_add(200, self.install_process)
 
     def on_click_me_clicked(self, button):
         silent_remove(f"{(altheapath)}/log.txt")
@@ -593,7 +607,7 @@ class Login(Gtk.Window):
         self.button.set_sensitive(False)
         self.realthread1 = threading.Thread(target=self.onclickmethread)
         self.realthread1.start()
-        GLib.idle_add(self.install_process)
+        self.start_install_monitor()
 
     def onclickmethread(self):
         ios_ver = parse_ios_version()
@@ -641,90 +655,68 @@ class Login(Gtk.Window):
         dialog2 = FailDialog(self)
         dialog2.run()
         dialog2.destroy()
+        self.monitor_stopped = True
         self.destroy()
         return False
 
     def install_process(self):
-        Installing = True
-        WarnTime = 0
-        TwoFactorTime = 0
+        # GLib.timeout_add callback: return True to keep polling the log,
+        # False to stop. Must never block, or the whole UI freezes.
         global InsAltStore
-        while Installing:
-            CheckIns = subprocess.run(
-                f'grep -F "Could not" {(altheapath)}/log.txt', shell=True
-            )
-            CheckWarn = subprocess.run(
-                f'grep -F "Are you sure you want to continue?" {(altheapath)}/log.txt',
-                shell=True,
-            )
-            CheckSuccess = subprocess.run(
-                f'grep -F "Notify: Installation Succeeded" {(altheapath)}/log.txt',
-                shell=True,
-            )
-            Check2fa = subprocess.run(
-                f'grep -F "Enter two factor code" {(altheapath)}/log.txt', shell=True
-            )
-            if CheckIns.returncode == 0:
+        if self.monitor_stopped:
+            return False
+        content = read_install_log(f"{altheapath}/log.txt")
+        if not content:
+            return True
+
+        if "Could not" in content:
+            InsAltStore.terminate()
+            global Failmsg
+            Failmsg = "\n".join(content.splitlines()[-6:])
+            dialog2 = FailDialog(self)
+            dialog2.run()
+            dialog2.destroy()
+            self.destroy()
+            return False
+        elif "Are you sure you want to continue?" in content and self.WarnTime == 0:
+            self.WarnTime = 1
+            global Warnmsg
+            Warnmsg = "\n".join(content.splitlines()[-8:])
+            dialog1 = WarningDialog(self)
+            response1 = dialog1.run()
+            dialog1.destroy()
+            if response1 == Gtk.ResponseType.OK:
+                if InsAltStore.stdin is not None:
+                    InsAltStore.stdin.write(b"\n")
+                    InsAltStore.stdin.flush()
+                return True
+            else:
                 InsAltStore.terminate()
-                Installing = False
-                global Failmsg
-                Failmsg = subprocess.check_output(
-                    f"tail -6 {(altheapath)}/log.txt", shell=True
-                ).decode()
-                dialog2 = FailDialog(self)
-                dialog2.run()
-                dialog2.destroy()
+                self.cancel()
                 self.destroy()
-            elif CheckWarn.returncode == 0 and WarnTime == 0:
-                Installing = False
-                word = "Are you sure you want to continue?"
-                # This fixes an issue where the warn window appears when it shouldn't
-                with open(f"{(altheapath)}/log.txt", "r") as file:
-                    # Read all content of the file
-                    content = file.read()
-                    # Check if a string present in the file
-                    if word in content:
-                        global Warnmsg
-                        Warnmsg = subprocess.check_output(
-                            f"tail -8 {('$HOME/.local/share/althea/log.txt')}",
-                            shell=True,
-                        ).decode()
-                        dialog1 = WarningDialog(self)
-                        response1 = dialog1.run()
-                        if response1 == Gtk.ResponseType.OK:
-                            dialog1.destroy()
-                            InsAltStore.communicate(input=b"\n")
-                            WarnTime = 1
-                            Installing = True
-                        elif response1 == Gtk.ResponseType.CANCEL:
-                            dialog1.destroy()
-                            os.system(f"pkill -TERM -P {InsAltStore.pid}")
-                            self.cancel()
-                    else:
-                        WarnTime = 1
-                        Installing = True
-            elif Check2fa.returncode == 0 and TwoFactorTime == 0:
-                Installing = False
-                dialog = VerificationDialog(self)
-                response = dialog.run()
-                if response == Gtk.ResponseType.OK:
-                    vercode = dialog.entry2.get_text()
-                    vercode = vercode + "\n"
-                    vercodebytes = bytes(vercode.encode())
-                    InsAltStore.communicate(input=vercodebytes)
-                    TwoFactorTime = 1
-                    dialog.destroy()
-                    Installing = True
-                elif response == Gtk.ResponseType.CANCEL:
-                    TwoFactorTime = 1
-                    os.system(f"pkill -TERM -P {InsAltStore.pid}")
-                    self.cancel()
-                    dialog.destroy()
-                    self.destroy()
-            elif CheckSuccess.returncode == 0:
-                Installing = False
-                self.success()
+                return False
+        elif "Enter two factor code" in content and self.TwoFactorTime == 0:
+            self.TwoFactorTime = 1
+            dialog = VerificationDialog(self)
+            response = dialog.run()
+            if response == Gtk.ResponseType.OK:
+                vercode = dialog.entry2.get_text() + "\n"
+                if InsAltStore.stdin is not None:
+                    InsAltStore.stdin.write(vercode.encode())
+                    InsAltStore.stdin.flush()
+                dialog.destroy()
+                return True
+            else:
+                dialog.destroy()
+                InsAltStore.terminate()
+                self.cancel()
                 self.destroy()
+                return False
+        elif "Notify: Installation Succeeded" in content:
+            self.success()
+            self.destroy()
+            return False
+        return True
 
     def success(self):
         dialog = Gtk.MessageDialog(

--- a/main.py
+++ b/main.py
@@ -40,18 +40,14 @@ computer_cpu_platform = platform.machine()
 
 def resource_path(relative_path):
     global installedcheck
-    CheckRun10 = subprocess.run(
-        f"find /usr/lib/althea/althea > /dev/null 2>&1", shell=True
-    )
-    if CheckRun10.returncode == 0:
+    installed_path = "/usr/lib/althea/althea"
+    if os.path.exists(installed_path):
         installedcheck = True
         base_path = "/usr/lib/althea"
     else:
-        base_path = os.path.abspath(".")
+        installedcheck = False
+        base_path = os.path.dirname(os.path.realpath(__file__))
     return os.path.join(base_path, relative_path)
-
-    installedcheck = subprocess.run("test -e /usr/lib/althea/althea", shell=True).returncode == 0
-    base_path = "/usr/lib/althea" if installedcheck else os.path.abspath(".")
 
 
 # Global variables
@@ -67,15 +63,16 @@ Warnmsg = "warn"
 Failmsg = "fail"
 icon_name = "changes-prevent-symbolic"
 command_six = Gtk.CheckMenuItem(label="Launch at Login")
-AltServer = "$HOME/.local/share/althea/AltServer"
-AnisetteServer = "$HOME/.local/share/althea/anisette-server"
-AltStore = "$HOME/.local/share/althea/AltStore.ipa"
-PATH = AltStore
-AutoStart = resource_path("resources/AutoStart.sh")
+home_dir = os.path.expanduser("~") or os.environ.get("HOME", "")
 altheapath = os.path.join(
-    os.environ.get("XDG_DATA_HOME") or f'{ os.environ["HOME"] }/.local/share',
+    os.environ.get("XDG_DATA_HOME") or os.path.join(home_dir, ".local", "share"),
     "althea",
 )
+AltServer = os.path.join(altheapath, "AltServer")
+AnisetteServer = os.path.join(altheapath, "anisette-server")
+AltStore = os.path.join(altheapath, "AltStore.ipa")
+PATH = AltStore
+AutoStart = resource_path("resources/AutoStart.sh")
 export_anisette = "export ALTSERVER_ANISETTE_SERVER='http://127.0.0.1:6969'"
 
 # Check version
@@ -589,8 +586,8 @@ class Login(Gtk.Window):
             silent_remove(f"{(altheapath)}/log.txt")
             #f = open(f"{(altheapath)}/log.txt", "w")
             #f.close()
-            if os.path.isdir(f'{ os.environ["HOME"] }/.adi'):
-                rmtree(f'{ os.environ["HOME"] }/.adi')
+            if os.path.isdir(os.path.join(home_dir, ".adi")):
+                rmtree(os.path.join(home_dir, ".adi"))
             InsAltStoreCMD = f"""{export_anisette} ; {(AltServer)} -u {UDID} -a {apple_id} -p \"{password}\" {PATH} > {("$HOME/.local/share/althea/log.txt")}"""
             InsAltStore = subprocess.Popen(
                 InsAltStoreCMD,
@@ -1066,8 +1063,7 @@ def main():
     GLib.set_prgname("althea")  # Sets the global program name
     global altheapath
     #global file_name
-    if not os.path.exists(altheapath):  # Creates $HOME/.local/share/althea
-        os.mkdir(altheapath)
+    os.makedirs(altheapath, exist_ok=True)
     if Gtk.StatusIcon.is_embedded:
         if connectioncheck():
             global indicator

--- a/main.py
+++ b/main.py
@@ -165,9 +165,18 @@ def paircheck():  # Check if the device is paired already
         return True
 
 def altstoreinstall(_):
-    if version.parse(ios_version()) < version.parse("15.0"):
+    ios_ver = parse_ios_version()
+    if ios_ver is None:
+        global Failmsg
+        Failmsg = "Could not read the iOS version.\nMake sure your device is connected and unlocked."
+        fail_dialog = FailDialog(parent=None)
+        fail_dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        fail_dialog.run()
+        fail_dialog.destroy()
+        return
+    if ios_ver < version.parse("15.0"):
         global Warnmsg
-        Warnmsg = f"""\niOS {ios_version()} is not supported by AltStore.\nThe lowest supported version is iOS 15.0.\nYou can still continue, but errors may occur.\n"""
+        Warnmsg = f"""\niOS {ios_ver} is not supported by AltStore.\nThe lowest supported version is iOS 15.0.\nYou can still continue, but errors may occur.\n"""
         ios_dialog = WarningDialog(parent=None)
         ios_dialog.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
         ios_response = ios_dialog.run()
@@ -202,15 +211,20 @@ def altserverfile(_):
 
 def notify():
     if (connectioncheck()) == True:
-        LatestVersion = (
-            urllib.request.urlopen(
-                "https://raw.githubusercontent.com/vyvir/althea/main/resources/version"
+        try:
+            LatestVersion = (
+                urllib.request.urlopen(
+                    "https://raw.githubusercontent.com/vyvir/althea/main/resources/version",
+                    timeout=10,
+                )
+                .readline()
+                .rstrip()
+                .decode()
             )
-            .readline()
-            .rstrip()
-            .decode()
-        )
-        if LatestVersion > LocalVersion:
+            update_available = version.parse(LatestVersion) > version.parse(LocalVersion)
+        except (OSError, version.InvalidVersion):
+            return False
+        if update_available:
             Notify.init("MyProgram")
             n = Notify.Notification.new(
                 "An update is available!",
@@ -364,6 +378,15 @@ def ios_version():
     silent_remove(f"{(altheapath)}/ideviceinfo.txt")
     print(result)
     return(result)
+
+
+def parse_ios_version():
+    # Returns None when no device is connected or ideviceinfo output
+    # could not be parsed, instead of crashing on version.parse("result").
+    try:
+        return version.parse(ios_version())
+    except version.InvalidVersion:
+        return None
 
 # Classes
 class SplashScreen(Handy.Window):
@@ -573,7 +596,8 @@ class Login(Gtk.Window):
         GLib.idle_add(self.install_process)
 
     def onclickmethread(self):
-        if ios_version() >= "15.0":
+        ios_ver = parse_ios_version()
+        if ios_ver is not None and ios_ver >= version.parse("15.0"):
             global savedcheck
             global apple_id
             global password
@@ -597,11 +621,20 @@ class Login(Gtk.Window):
             )
         else:
             global Failmsg
-            Failmsg = "iOS 15.0 or later is required."
-            dialog2 = FailDialog(self)
-            dialog2.run()
-            dialog2.destroy()
-            self.destroy()
+            if ios_ver is None:
+                Failmsg = "Could not read the iOS version.\nMake sure your device is connected and unlocked."
+            else:
+                Failmsg = "iOS 15.0 or later is required."
+            GLib.idle_add(self.show_fail_and_close)
+
+    def show_fail_and_close(self):
+        # GTK must only be touched from the main thread; worker threads
+        # schedule this via GLib.idle_add.
+        dialog2 = FailDialog(self)
+        dialog2.run()
+        dialog2.destroy()
+        self.destroy()
+        return False
 
     def install_process(self):
         Installing = True

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 import os
 import errno
-from shutil import rmtree
+from shutil import rmtree, which
 import json
 import urllib.request
 from urllib.request import urlopen
@@ -608,16 +608,24 @@ class Login(Gtk.Window):
             global InsAltStore
             print(PATH)
             silent_remove(f"{(altheapath)}/log.txt")
-            #f = open(f"{(altheapath)}/log.txt", "w")
-            #f.close()
             if os.path.isdir(os.path.join(home_dir, ".adi")):
                 rmtree(os.path.join(home_dir, ".adi"))
-            InsAltStoreCMD = f"""{export_anisette} ; {(AltServer)} -u {UDID} -a {apple_id} -p \"{password}\" {PATH} > {("$HOME/.local/share/althea/log.txt")}"""
+            env = dict(os.environ, ALTSERVER_ANISETTE_SERVER="http://127.0.0.1:6969")
+            log_file = open(f"{(altheapath)}/log.txt", "wb")
+            # No shell: credentials/paths with spaces or shell metacharacters
+            # must not be interpolated into a command string.
+            launch_cmd = [AltServer, "-u", UDID, "-a", apple_id, "-p", password, PATH]
+            if which("stdbuf") is not None:
+                # Line-buffer AltServer's output so 2FA/warning prompts reach
+                # log.txt promptly; fall back gracefully where coreutils'
+                # stdbuf is unavailable.
+                launch_cmd = ["stdbuf", "-oL", "-eL"] + launch_cmd
             InsAltStore = subprocess.Popen(
-                InsAltStoreCMD,
+                launch_cmd,
                 stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                shell=True,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                env=env,
             )
         else:
             global Failmsg

--- a/main.py
+++ b/main.py
@@ -121,7 +121,7 @@ def menu():
             f"test -e $HOME/.config/autostart/althea.desktop", shell=True
         )
         if CheckRun12.returncode == 0:
-            command_six.set_active(command_six)
+            command_six.set_active(True)
         command_six.connect("activate", launchatlogin1)
         menu.append(Gtk.SeparatorMenuItem())
         menu.append(command_six)
@@ -487,7 +487,7 @@ class SplashScreen(Handy.Window):
                 allow_redirects=True,
             )
             open(f"{(altheapath)}/am.apk", "wb").write(r.content)
-            os.makedirs(f"{(altheapath)}/lib/x86_64")
+            os.makedirs(f"{(altheapath)}/lib/x86_64", exist_ok=True)
             self.loadalthea.set_fraction(0.3)
             self.lbl1.set_text("Extracting necessary libraries...")
             CheckRunB = subprocess.run(
@@ -500,9 +500,9 @@ class SplashScreen(Handy.Window):
             )
             silent_remove(f"{(altheapath)}/am.apk")
             self.loadalthea.set_fraction(0.4)
-        self.lbl1.set_text("Starting anisette-server...")
-        subprocess.run(f"{(altheapath)}/anisette-server -n 127.0.0.1 -p 6969 &", shell=True)
-        #subprocess.run(f"cd {(altheapath)} && ./anisette-server &", shell=True)#-n 127.0.0.1 -p 6969 &", shell=True
+        if CheckRun.returncode != 0:
+            self.lbl1.set_text("Starting anisette-server...")
+            subprocess.run(f"{(altheapath)}/anisette-server -n 127.0.0.1 -p 6969 &", shell=True)
         self.loadalthea.set_fraction(0.5)
         finished = False
         while not finished:

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import main
+
+
+class MainPathTests(unittest.TestCase):
+    def test_resource_path_uses_repo_tree_when_not_installed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                path = main.resource_path("resources/version")
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertTrue(path.endswith("resources/version"))
+        self.assertTrue(os.path.exists(path))
+
+    def test_runtime_paths_resolve_from_data_directory(self):
+        self.assertEqual(main.AltServer, os.path.join(main.altheapath, "AltServer"))
+        self.assertEqual(
+            main.AnisetteServer,
+            os.path.join(main.altheapath, "anisette-server"),
+        )
+        self.assertEqual(main.AltStore, os.path.join(main.altheapath, "AltStore.ipa"))
+
+    def test_install_log_helper_handles_missing_file_and_success(self):
+        log_path = os.path.join(main.altheapath, "log.txt")
+        if os.path.exists(log_path):
+            os.remove(log_path)
+
+        log_text = main.read_install_log(log_path)
+        self.assertEqual(log_text, "")
+
+        with open(log_path, "w", encoding="utf-8") as handle:
+            handle.write("Notify: Installation Succeeded\n")
+
+        self.assertIn("Notify: Installation Succeeded", main.read_install_log(log_path))
+
+    def test_parse_ios_version_handles_no_device_and_real_versions(self):
+        original = main.ios_version
+        try:
+            main.ios_version = lambda: "result"  # ideviceinfo failed / no device
+            self.assertIsNone(main.parse_ios_version())
+
+            main.ios_version = lambda: "9.3"
+            self.assertLess(main.parse_ios_version(), main.version.parse("15.0"))
+
+            main.ios_version = lambda: "26.1"
+            self.assertGreaterEqual(main.parse_ios_version(), main.version.parse("15.0"))
+        finally:
+            main.ios_version = original
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hey! 👋

Quick heads up before anything else: I'm not a hardcore dev, and I worked through these changes with Claude (Claude Code). I kept running into the flaky pairing/install behavior that others have mentioned too, where sometimes it works and sometimes it just doesn't. Instead of only patching my own machine I figured I'd try to clean it up properly and send it back, in hopes it makes althea more stable for future users. No shame in the AI assist, but I want to be upfront about it. Happy to change anything you don't like.

Each fix is its own commit so they're easy to review or drop individually:

- **The UI froze during installs.** The install monitor was a blocking while loop that kept spawning grep subprocesses against the log file. It's now a GLib timeout that reads the log in-process, so the window stays responsive and the 2FA / "are you sure" prompts show up reliably instead of racing the loop.
- **Passwords went through the shell.** AltServer was launched with an f-string shell command with the Apple ID and password pasted straight in, so a password with a space or a shell character could break the whole thing. It uses an argv list now, no shell involved. When coreutils' stdbuf is available it line-buffers the output so prompts reach the log faster, and when it's not, the launch still works.
- **Crash when no device was connected.** version.parse() blew up trying to parse the fallback string from ideviceinfo. There's now a helper that returns None and shows a "connect and unlock your device" message instead.
- **iOS versions were compared as plain strings**, which breaks with double digit versions. The update check in notify() had the same problem and no timeout, fixed both.
- **Path handling cleanup:** respects XDG_DATA_HOME, real paths instead of "$HOME" strings that only worked inside shell commands, and resource_path() no longer shells out to find.
- **AltStore feed download hardened:** matches by bundleIdentifier (the feed literally has two apps both named "AltStore" now), skips the Patreon entries that don't link to a direct .ipa, and has timeouts and error handling.
- **Small stuff:** don't start a second anisette-server when one is already answering on port 6969, a makedirs crash on second run, and the Launch at Login checkbox getting passed a widget instead of True.
- Added a small unittest file for the helpers.

One thing I could not fix and want to flag for whoever comes next: on iOS 26 the sideload itself succeeds but AltStore crashes the moment you open it. That one is not althea's fault. iOS 26 got stricter about signature validation, and the official AltServer fixed it in 1.7.4 by updating their codesigning library, but AltServer-Linux (the binary althea downloads) is still v0.0.5 from 2022 and has not gotten that fix (NyaMisty/AltServer-Linux#131). There's a fork experimenting with routing the signing through rcodesign, but no released binary with it yet, so I left that alone rather than ship something I couldn't verify. Documenting it here so the next person doesn't spend a weekend confused like I did.

Thanks for making althea 🙏
